### PR TITLE
www-client/chromium: fix gentoo bug 636586

### DIFF
--- a/www-client/chromium/chromium-62.0.3202.75.ebuild
+++ b/www-client/chromium/chromium-62.0.3202.75.ebuild
@@ -96,7 +96,7 @@ DEPEND="${COMMON_DEPEND}
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	>=dev-util/ninja-1.7.2
-	>=net-libs/nodejs-4.6.1
+	>=net-libs/nodejs-6.9.4
 	sys-apps/hwids[usb(+)]
 	>=sys-devel/bison-2.4.3
 	sys-devel/flex


### PR DESCRIPTION
it doesn't build anymore with nodejs-4.6.1