### PR TITLE
IUSE: add cpu_flags_arm_neon, cpu_flags_arm_thumb2

### DIFF
--- a/dev-lang/rust/rust-1.39.0.ebuild
+++ b/dev-lang/rust/rust-1.39.0.ebuild
@@ -34,7 +34,7 @@ LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/?}
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4 UoI-NCSA"
 
-IUSE="clippy cpu_flags_x86_sse2 debug doc libressl miri rls rustfmt system-llvm wasm ${ALL_LLVM_TARGETS[*]}"
+IUSE="clippy cpu_flags_arm_neon cpu_flags_arm_thumb2 cpu_flags_x86_sse2 debug doc libressl miri rls rustfmt system-llvm wasm ${ALL_LLVM_TARGETS[*]}"
 
 # Please keep the LLVM dependency block separate. Since LLVM is slotted,
 # we need to *really* make sure we're not pulling more than one slot


### PR DESCRIPTION
Fixes build failure on arm due to cpu_flags_arm_neon not in IUSE but called.