### PR TITLE
dev-lang/rust: remove http-parser dependency

### DIFF
--- a/dev-lang/rust/rust-1.48.0.ebuild
+++ b/dev-lang/rust/rust-1.48.0.ebuild
@@ -85,7 +85,6 @@ BDEPEND="${PYTHON_DEPS}
 DEPEND="
 	>=app-arch/xz-utils-5.2
 	net-libs/libssh2:=
-	net-libs/http-parser:=
 	net-misc/curl:=[http2,ssl]
 	elibc_musl? ( >=sys-libs/musl-1.2.1-r2 )
 	sys-libs/zlib:=

--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -85,7 +85,6 @@ BDEPEND="${PYTHON_DEPS}
 DEPEND="
 	>=app-arch/xz-utils-5.2
 	net-libs/libssh2:=
-	net-libs/http-parser:=
 	net-misc/curl:=[http2,ssl]
 	elibc_musl? ( >=sys-libs/musl-1.2.1-r2 )
 	sys-libs/zlib:=


### PR DESCRIPTION
this was removed in rust-1.46.0, lddtree /usr/bin/cargo for evidence

please merge if you agree with me 