### PR TITLE
dev-lang/rust: use bundled libssh2

### DIFF
--- a/dev-lang/rust/rust-1.49.0.ebuild
+++ b/dev-lang/rust/rust-1.49.0.ebuild
@@ -84,7 +84,6 @@ BDEPEND="${PYTHON_DEPS}
 
 DEPEND="
 	>=app-arch/xz-utils-5.2
-	net-libs/libssh2:=
 	net-misc/curl:=[http2,ssl]
 	elibc_musl? ( >=sys-libs/musl-1.2.1-r2 )
 	sys-libs/zlib:=
@@ -215,8 +214,6 @@ pkg_setup() {
 	# required to link agains system libs, otherwise
 	# crates use bundled sources and compile own static version
 	export LIBGIT2_NO_PKG_CONFIG=1 #749381
-	export LIBSSH2_SYS_USE_PKG_CONFIG=1
-	export PKG_CONFIG_ALLOW_CROSS=1
 
 	use system-bootstrap && boostrap_rust_version_check
 


### PR DESCRIPTION
follow gentoo decision to remove system-libssh2, trying to avoid abi nightmare in the future during +system-bootstrap 